### PR TITLE
Make code blocks editable on slides with run button

### DIFF
--- a/2026/gi-meetup/slides/play.js
+++ b/2026/gi-meetup/slides/play.js
@@ -1,4 +1,15 @@
 console.log("loading play.js ...");
+document.addEventListener("DOMContentLoaded", function () {
+  document.querySelectorAll("button[data-header-id]").forEach(function (btn) {
+    var headerId = btn.dataset.headerId;
+    var container = document.getElementById(headerId) && document.getElementById(headerId).parentNode;
+    var codeEl = container && container.querySelector("code");
+    if (codeEl) {
+      codeEl.contentEditable = "true";
+      codeEl.spellcheck = false;
+    }
+  });
+});
 document.addEventListener("click", function (event) {
   //console.log("click target:", event.target.tagName, event.target.outerHTML);
   var btn = event.target.closest("button");
@@ -42,4 +53,4 @@ function runCode(code, outputEl) {
       }
     })
     .catch((err) => console.log("fetch error", err));
-} 
+}

--- a/2026/gi-meetup/slides/play.js
+++ b/2026/gi-meetup/slides/play.js
@@ -4,9 +4,19 @@ document.addEventListener("DOMContentLoaded", function () {
     var headerId = btn.dataset.headerId;
     var container = document.getElementById(headerId) && document.getElementById(headerId).parentNode;
     var codeEl = container && container.querySelector("code");
+    var outputDiv = btn.parentNode;
+    var btnClone = btn.cloneNode(true);
     if (codeEl) {
       codeEl.contentEditable = "true";
       codeEl.spellcheck = false;
+      codeEl.addEventListener("input", function () {
+        if (outputDiv.classList.contains("output")) {
+          outputDiv.textContent = "";
+          outputDiv.appendChild(btnClone.cloneNode(true));
+          outputDiv.classList.remove("output");
+          outputDiv.removeAttribute("align");
+        }
+      });
     }
   });
 });

--- a/2026/gi-meetup/slides/title.md
+++ b/2026/gi-meetup/slides/title.md
@@ -31,6 +31,10 @@ button {
   font-size: 18px;
   font-weight: bold;
 }
+code[contenteditable]:focus {
+  outline: 2px solid orange;
+  cursor: text;
+}
 .output {
   background: gray;
   color: white;


### PR DESCRIPTION
Sets `contenteditable` on code blocks next to run buttons so presenters can edit code live before running.